### PR TITLE
Remove timeout -t option for BusyBox

### DIFF
--- a/wait-for-it.sh
+++ b/wait-for-it.sh
@@ -53,9 +53,9 @@ wait_for_wrapper()
 {
     # In order to support SIGINT during timeout: http://unix.stackexchange.com/a/57692
     if [[ $QUIET -eq 1 ]]; then
-        timeout $BUSYTIMEFLAG $TIMEOUT $0 --quiet --child --host=$HOST --port=$PORT --timeout=$TIMEOUT &
+        timeout $TIMEOUT $0 --quiet --child --host=$HOST --port=$PORT --timeout=$TIMEOUT &
     else
-        timeout $BUSYTIMEFLAG $TIMEOUT $0 --child --host=$HOST --port=$PORT --timeout=$TIMEOUT &
+        timeout $TIMEOUT $0 --child --host=$HOST --port=$PORT --timeout=$TIMEOUT &
     fi
     PID=$!
     trap "kill -INT -$PID" INT
@@ -146,10 +146,8 @@ QUIET=${QUIET:-0}
 TIMEOUT_PATH=$(realpath $(which timeout))
 if [[ $TIMEOUT_PATH =~ "busybox" ]]; then
         ISBUSY=1
-        BUSYTIMEFLAG="-t"
 else
         ISBUSY=0
-        BUSYTIMEFLAG=""
 fi
 
 if [[ $CHILD -gt 0 ]]; then


### PR DESCRIPTION
Breaking change in BusyBox(used in Alpine Linux) was introduced, the change is needed to continue to use the script with Alpine based images.